### PR TITLE
fix(module): correct composable name

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -446,7 +446,7 @@ declare module 'h3' {
       from: '#internal/nuxt-simple-robots',
       imports: [
         'getPathRobotConfig',
-        'getSiteIndexable',
+        'getSiteRobotConfig',
       ],
     }
     nuxt.options.nitro = nuxt.options.nitro || {}


### PR DESCRIPTION

### Description

It most likely should be `getSiteRobotConfig`, right?

### Linked Issues

n/a

### Additional context

n/a
