### PR TITLE
docs: remove `nuxt.config` section in Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,10 @@ Tame the robots crawling and indexing your Nuxt site with ease.
 
 ## Installation
 
-1. Install `nuxt-simple-robots` dependency to your project:
+Install `nuxt-simple-robots` dependency to your project:
 
 ```bash
 npx nuxi@latest module add simple-robots
-```
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ['nuxt-simple-robots']
-})
 ```
 
 # Documentation


### PR DESCRIPTION
### Description

`nuxi module add` section has been added for `simple-robots` in #83  issue.

nuxt.config is automatically added by Nuxi, so I removed (2).

### Linked Issues


### Additional context
